### PR TITLE
Simplify preventing shaders from loading multiple times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ homepage = "https://github.com/Braymatter/bevy_tiling_background"
 
 [dependencies]
 bevy = { version = "0.9", default-features = false, features = ["bevy_asset", "render"] }
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 bevy = { version = "0.9", default-features = false, features = ["bevy_asset", "render", "bevy_winit", "png"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::sync::RwLock;
+use std::sync::Once;
 
 use bevy::app::{App, Plugin};
 use bevy::asset::{load_internal_asset, LoadState};
@@ -11,7 +11,6 @@ use bevy::render::render_resource::{AddressMode, AsBindGroup, SamplerDescriptor,
 use bevy::render::texture::ImageSampler;
 use bevy::sprite::{Material2d, Material2dPlugin, Mesh2dHandle};
 use bevy::window::WindowResized;
-use lazy_static::lazy_static;
 
 pub const TILED_BG_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 429593476423978);
@@ -19,10 +18,8 @@ pub const TILED_BG_SHADER_HANDLE: HandleUntyped =
 pub const BGLIB_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 429593476423988);
 
-lazy_static! {
-    /// Used to prevent the libraries shaders from being loaded multiple times, emitting events etc.
-    pub static ref BEVY_TILING_PLUGIN_SHADERS_LOADED: RwLock<bool> = RwLock::new(false);
-}
+/// Prevent shaders from being loaded multiple times, emitting events etc.
+pub static BEVY_TILING_PLUGIN_SHADERS_LOADED: Once = Once::new();
 
 fn load_plugin_shadercode(app: &mut App) {
     load_internal_asset!(
@@ -50,18 +47,10 @@ where
     T::Data: Clone + Eq + Send + Sync + Clone + Sized + Hash,
 {
     fn build(&self, app: &mut App) {
-        if let Ok(mut guard) = BEVY_TILING_PLUGIN_SHADERS_LOADED.write() {
-            if !*guard {
-                info!("Loading bevy_tiling_background shaders");
-                load_plugin_shadercode(app);
-                *guard = true;
-            } else {
-                info!("bevy_tiling_background shaders already loaded. Skipped loading again.");
-            }
-        } else {
-            warn!("Could not get RwLockWriteGuard to read shadercode loading state. Potentially reloading shaders.");
-            load_plugin_shadercode(app)
-        }
+        BEVY_TILING_PLUGIN_SHADERS_LOADED.call_once(|| {
+            info!("Loading bevy_tiling_background shaders");
+            load_plugin_shadercode(app);
+        });
 
         app.add_plugin(Material2dPlugin::<T>::default())
             .insert_resource(UpdateSamplerRepeating::default())


### PR DESCRIPTION
Rust's `Once` primitive allows us to simplify the code, reduce failure states, and remove the lazy_static dependency.

## Migration Guide
BEVY_TILING_PLUGIN_SHADERS_LOADED type is now `Once`. Use `BEVY_TILING_PLUGIN_SHADERS_LOADED.is_completed()` to check if the shaders are loading instead of using the guard to get the boolean
 value.