### PR TITLE
Use fullscreen vertex shader, removing camera hierarchy requirements

### DIFF
--- a/assets/custombg.wgsl
+++ b/assets/custombg.wgsl
@@ -1,3 +1,4 @@
+#import bevy_core_pipeline::fullscreen_vertex_shader
 #import bevy_sprite::mesh2d_view_bindings
 #import bevy_sprite::mesh2d_bindings
 #import bevy_sprite::mesh2d_functions
@@ -21,7 +22,7 @@ var texture_sampler: sampler;
 @fragment
 fn fragment(
     @builtin(position) position: vec4<f32>,
-    #import bevy_pbr::mesh_vertex_output
+    @location(0) uv: vec2<f32>,
 ) -> @location(0) vec4<f32> {
     let scale = uniforms.scale;
     let offset = mesh2d_position_world_to_clip(vec4<f32>(view.world_position.xy, 0.0, 0.0)).xy;

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -13,9 +13,6 @@ pub fn main() {
         .run()
 }
 
-#[derive(Component)]
-struct CameraRig;
-
 pub fn setup(
     mut commands: Commands,
     asset_server: ResMut<AssetServer>,
@@ -30,21 +27,19 @@ pub fn setup(
     // Queue a command to set the image to be repeating once the image is loaded.
     commands.set_image_repeating(front_layer.clone());
 
-    // Spawn camera rig with camera and backgrounds as children
-    commands
-        .spawn((CameraRig, SpatialBundle::default()))
-        .with_children(|child_builder| {
-            child_builder.spawn(Camera2dBundle::default());
-            child_builder.spawn(
-                BackgroundImageBundle::from_image(image, materials.as_mut(), meshes.as_mut())
-                    .at_z_layer(0.1),
-            );
-            child_builder.spawn(
-                BackgroundImageBundle::from_image(front_layer, materials.as_mut(), meshes.as_mut())
-                    .at_z_layer(2.1)
-                    .with_movement_scale(0.25),
-            );
-        });
+    // Spawn camera
+    commands.spawn(Camera2dBundle::default());
+
+    // Spawn backgrounds
+    commands.spawn(
+        BackgroundImageBundle::from_image(image, materials.as_mut(), meshes.as_mut())
+            .at_z_layer(0.1),
+    );
+    commands.spawn(
+        BackgroundImageBundle::from_image(front_layer, materials.as_mut(), meshes.as_mut())
+            .at_z_layer(2.1)
+            .with_movement_scale(1.1),
+    );
 
     // Instructions
     commands.spawn((
@@ -77,8 +72,8 @@ struct Instructions;
 struct Player;
 
 fn movement(
-    mut camera: Query<&mut Transform, With<CameraRig>>,
-    mut sprite_transform: Query<(&mut Transform, &Player), Without<CameraRig>>,
+    mut camera: Query<&mut Transform, With<Camera>>,
+    mut sprite_transform: Query<(&mut Transform, &Player), Without<Camera>>,
     mut background_scales: Query<&mut BackgroundMovementScale<BackgroundMaterial>>,
     input: Res<Input<KeyCode>>,
     time: Res<Time>,

--- a/examples/tiling.rs
+++ b/examples/tiling.rs
@@ -4,14 +4,9 @@ use bevy_tiling_background::{
     TilingBackgroundPlugin,
 };
 
-/// Bevy doesn't render things that are attached to the camera, so this component will be used
-/// on a parent entity to move our camera and background.
-#[derive(Component)]
-pub struct CameraRig;
-
 pub fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_linear()))
         .add_plugin(TilingBackgroundPlugin::<BackgroundMaterial>::default())
         .add_startup_system(setup)
         .add_system(movement)
@@ -30,16 +25,12 @@ pub fn setup(
     // Queue a command to set the image to be repeating once the image is loaded.
     commands.set_image_repeating(image.clone());
 
-    // Spawn camera rig with camera and background as children
-    commands
-        .spawn((CameraRig, SpatialBundle::default()))
-        .with_children(|child_builder| {
-            child_builder.spawn(Camera2dBundle::default());
-            child_builder.spawn(
-                BackgroundImageBundle::from_image(image, materials.as_mut(), meshes.as_mut())
-                    .at_z_layer(0.1),
-            );
-        });
+    commands.spawn(Camera2dBundle::default());
+
+    commands.spawn(
+        BackgroundImageBundle::from_image(image, materials.as_mut(), meshes.as_mut())
+            .at_z_layer(0.1),
+    );
 
     // Instructions
     commands.spawn((
@@ -87,7 +78,7 @@ pub fn setup(
 struct Instructions;
 
 fn movement(
-    mut camera: Query<&mut Transform, With<CameraRig>>,
+    mut camera: Query<&mut Transform, With<Camera>>,
     mut background_scales: Query<&mut BackgroundMovementScale<BackgroundMaterial>>,
     input: Res<Input<KeyCode>>,
     time: Res<Time>,

--- a/src/shaders/background.wgsl
+++ b/src/shaders/background.wgsl
@@ -1,3 +1,4 @@
+#import bevy_core_pipeline::fullscreen_vertex_shader
 #import bevy_sprite::mesh2d_view_bindings
 #import bevy_sprite::mesh2d_bindings
 #import bevy_sprite::mesh2d_functions
@@ -17,7 +18,7 @@ var texture_sampler: sampler;
 @fragment
 fn fragment(
     @builtin(position) position: vec4<f32>,
-    #import bevy_pbr::mesh_vertex_output
+    @location(0) uv: vec2<f32>,
 ) -> @location(0) vec4<f32> {
     let scale = uniforms.scale;
     let offset = mesh2d_position_world_to_clip(vec4<f32>(view.world_position.xy, 0.0, 0.0)).xy;

--- a/src/shaders/bglib.wgsl
+++ b/src/shaders/bglib.wgsl
@@ -7,9 +7,20 @@ fn scroll(
     uv: vec2<f32>,
     offset: vec2<f32>,
 ) -> vec4<f32>{
+    // Get the Normalized Device Coordinates.
+    // NDC defines the screen space with a range from -1 to 1.
+    // This works better when resizing the window as the background keeps it's position relative to other objects.
+    //
+    // Top Left           Top Right
+    // (-1, -1)  ( 0, -1)  ( 1, -1)
+    // (-1,  0)  ( 0,  0)  ( 1,  0)
+    // (-1,  1)  ( 0,  1)  ( 1,  1)
+    // Bottom Left     Bottom Right
+    let ndc = (uv - vec2<f32>(0.5, 0.5)) * 2.0;
+
     let offset = vec2<f32>(-offset.x, offset.y);
-    
-    var uv = (uv - offset * scale);
+
+    var uv = ndc - (offset * scale);
     let tex_dim = textureDimensions(texture);
     
     uv = uv * ( view.viewport.zw / vec2<f32>(tex_dim) );


### PR DESCRIPTION
# Changelog
- Remove camera hierarchy requirements
- BackgroundMovementScale.scale now defaults to 1.0
- BackgroundMovementScale.scale mapping changed to be more intuitive. E.g. 0.75 now scrolls the background 0.75 X the speed of the camera.

# Migration Guide
- BackgroundMovementScale.scale has changed it's value mapping. If you used the default it should function similar to the new default and won't require changes. The formula for converting to the new value should be roughly `(old_value - 0.15)  + 1.0` (might not be exact)
- If using a custom shader, the fragment inputs have changed and there is a new import. See [custombg.wgsl](https://github.com/Braymatter/bevy_tiling_background/blob/main/assets/custombg.wgsl)
  Also, where you implement Material2d for your custom material you will need to add a specialize function and vertex_shader as shown below, see the [`custom`](https://github.com/BraymatterOrg/bevy_tiling_background/blob/9d49665770b60c6841382d6944a715650fe74980/examples/custom.rs) example for more details.
  ```rust
  use bevy::core_pipeline::fullscreen_vertex_shader::FULLSCREEN_SHADER_HANDLE;

  impl Material2d for CustomMaterial {
      fn vertex_shader() -> ShaderRef {
          FULLSCREEN_SHADER_HANDLE.typed().into()
      }
      fn fragment_shader() -> ShaderRef {
          "custombg.wgsl".into()
      }

      fn specialize(
          descriptor: &mut RenderPipelineDescriptor,
          _: &MeshVertexBufferLayout,
          _: Material2dKey<Self>,
      ) -> Result<(), SpecializedMeshPipelineError> {
          descriptor.primitive = PrimitiveState::default();
          descriptor.vertex.entry_point = "fullscreen_vertex_shader".into();
          Ok(())
      }
  }
  ```