### PR TITLE
Remove type parameter so BackgroundMovementScale can implement Reflect

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use bevy::core_pipeline::fullscreen_vertex_shader::FULLSCREEN_SHADER_HANDLE;
 use bevy::render::mesh::MeshVertexBufferLayout;
 use bevy::render::render_resource::{
@@ -55,10 +53,7 @@ pub fn setup(
             materials.as_mut(),
             meshes.as_mut(),
         ))
-        .insert(BackgroundMovementScale {
-            scale: 0.00,
-            _phantom: PhantomData::<CustomMaterial>::default(),
-        });
+        .insert(BackgroundMovementScale { scale: 0.00 });
 
     // Instructions
     commands.spawn((

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -74,7 +74,7 @@ struct Player;
 fn movement(
     mut camera: Query<&mut Transform, With<Camera>>,
     mut sprite_transform: Query<(&mut Transform, &Player), Without<Camera>>,
-    mut background_scales: Query<&mut BackgroundMovementScale<BackgroundMaterial>>,
+    mut background_scales: Query<&mut BackgroundMovementScale>,
     input: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {

--- a/examples/tiling.rs
+++ b/examples/tiling.rs
@@ -79,7 +79,7 @@ struct Instructions;
 
 fn movement(
     mut camera: Query<&mut Transform, With<Camera>>,
-    mut background_scales: Query<&mut BackgroundMovementScale<BackgroundMaterial>>,
+    mut background_scales: Query<&mut BackgroundMovementScale>,
     input: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
@@ -114,7 +114,7 @@ fn movement(
 
 fn update_instructions(
     mut query: Query<&mut Text, With<Instructions>>,
-    background_movement: Query<&BackgroundMovementScale<BackgroundMaterial>>,
+    background_movement: Query<&BackgroundMovementScale>,
 ) {
     let mut instructions = query.single_mut();
     instructions.sections.first_mut().unwrap().value = format!(
@@ -127,11 +127,8 @@ fn update_instructions(
 
 pub fn update_movement_scale_system(
     mut query: Query<
-        (
-            &mut Handle<BackgroundMaterial>,
-            &BackgroundMovementScale<BackgroundMaterial>,
-        ),
-        Changed<BackgroundMovementScale<BackgroundMaterial>>,
+        (&mut Handle<BackgroundMaterial>, &BackgroundMovementScale),
+        Changed<BackgroundMovementScale>,
     >,
     mut background_materials: ResMut<Assets<BackgroundMaterial>>,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@ where
 
     pub fn update_movement_scale_system(
         mut query: Query<
-            (&mut Handle<T>, &BackgroundMovementScale<T>),
-            Changed<BackgroundMovementScale<T>>,
+            (&mut Handle<T>, &BackgroundMovementScale),
+            Changed<BackgroundMovementScale>,
         >,
         mut background_materials: ResMut<Assets<T>>,
     ) {
@@ -130,7 +130,7 @@ pub trait ScrollingBackground {
     fn set_movement(&mut self, movement: f32);
 }
 
-#[derive(AsBindGroup, Debug, Clone, TypeUuid, Default)]
+#[derive(AsBindGroup, Debug, Clone, TypeUuid, Default, Reflect)]
 #[uuid = "4e31d7bf-a3f5-4a62-a86f-1e61a21076db"]
 pub struct BackgroundMaterial {
     #[uniform(0)]
@@ -224,8 +224,9 @@ fn update_sampler_on_loaded_system(
     }
 }
 
-#[derive(Component)]
-pub struct BackgroundMovementScale<T: Material2d> {
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+pub struct BackgroundMovementScale {
     /// Determines how fast the background will scroll when the camera moves.
     ///
     /// # Examples
@@ -235,15 +236,11 @@ pub struct BackgroundMovementScale<T: Material2d> {
     /// making it stationary in the world.
     /// - A scale of 2.0 the background will move twice as fast as the camera.
     pub scale: f32,
-    pub _phantom: PhantomData<T>,
 }
 
-impl<T: Material2d> Default for BackgroundMovementScale<T> {
+impl Default for BackgroundMovementScale {
     fn default() -> Self {
-        Self {
-            scale: 1.0,
-            _phantom: PhantomData::default(),
-        }
+        Self { scale: 1.0 }
     }
 }
 
@@ -255,7 +252,7 @@ pub struct CustomBackgroundImageBundle<T: Material2d> {
     pub global_transform: GlobalTransform,
     pub visibility: Visibility,
     pub computed_visibility: ComputedVisibility,
-    pub movement_scale: BackgroundMovementScale<T>,
+    pub movement_scale: BackgroundMovementScale,
 }
 
 impl<T: Material2d + ScrollingBackground> CustomBackgroundImageBundle<T> {
@@ -288,7 +285,7 @@ pub struct BackgroundImageBundle {
     pub global_transform: GlobalTransform,
     pub visibility: Visibility,
     pub computed_visibility: ComputedVisibility,
-    pub movement_scale: BackgroundMovementScale<BackgroundMaterial>,
+    pub movement_scale: BackgroundMovementScale,
 }
 
 impl BackgroundImageBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ where
         });
 
         app.add_plugin(Material2dPlugin::<T>::default())
+            .register_type::<BackgroundMovementScale>()
             .insert_resource(UpdateSamplerRepeating::default())
             .add_system_to_stage(CoreStage::PostUpdate, Self::on_window_resize)
             .add_system(Self::on_background_added)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ fn update_sampler_on_loaded_system(
 }
 
 #[derive(Component, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct BackgroundMovementScale {
     /// Determines how fast the background will scroll when the camera moves.
     ///


### PR DESCRIPTION
The type parameter on BackgroundMovementScale didn't seem to be used and prevented us from implementing Reflect.
Reflect allows us to change the movement scale using bevy_egui_inspector.

Technically this does prevent us from having multiple backgrounds with different movement scales on the same entity but you can just use two entities. It would probably be confusing to have two backgrounds on the same entity if it even works. Being able to inspect it is much more useful.

## Changelog

- Removed type parameter from BackgroundMovementScale 

## Migration Guide

- You should be able to simply remove the type parameter from BackgroundMovementScale wherever it is used in your code. 