### PR TITLE
Revert uv conversion to NDC space to fix pixel art artifacts

### DIFF
--- a/src/shaders/bglib.wgsl
+++ b/src/shaders/bglib.wgsl
@@ -7,20 +7,9 @@ fn scroll(
     uv: vec2<f32>,
     offset: vec2<f32>,
 ) -> vec4<f32>{
-    // Get the Normalized Device Coordinates.
-    // NDC defines the screen space with a range from -1 to 1.
-    // This works better when resizing the window as the background keeps it's position relative to other objects.
-    //
-    // Top Left           Top Right
-    // (-1, -1)  ( 0, -1)  ( 1, -1)
-    // (-1,  0)  ( 0,  0)  ( 1,  0)
-    // (-1,  1)  ( 0,  1)  ( 1,  1)
-    // Bottom Left     Bottom Right
-    let ndc = (uv - vec2<f32>(0.5, 0.5)) * 2.0;
-
     let offset = vec2<f32>(-offset.x, offset.y);
 
-    var uv = ndc - (offset * scale);
+    var uv = uv - (offset * scale);
     let tex_dim = textureDimensions(texture);
     
     uv = uv * ( view.viewport.zw / vec2<f32>(tex_dim) );


### PR DESCRIPTION
I think it will be the way to go, but need to find a solution for the artifacts first. Reverting for now.