### PR TITLE
Use a const asset handle for the background mesh

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,9 @@
+# Unreleased
+
+- Remove meshes parameter when calling `BackgroundImageBundle::from_image` or `CustomBackgroundImageBundle::with_material`.
+  ```rust
+  // Old
+  BackgroundImageBundle::from_image(image, materials, meshes)
+  // New
+  BackgroundImageBundle::from_image(image, materials)
+  ```

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -30,7 +30,6 @@ pub fn setup(
     mut commands: Commands,
     asset_server: ResMut<AssetServer>,
     mut materials: ResMut<Assets<CustomMaterial>>,
-    mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let image = asset_server.load("space_test.png");
     // Queue a command to set the image to be repeating once the image is loaded.
@@ -51,7 +50,6 @@ pub fn setup(
         .spawn(CustomBackgroundImageBundle::with_material(
             custom_mat,
             materials.as_mut(),
-            meshes.as_mut(),
         ))
         .insert(BackgroundMovementScale { scale: 0.00 });
 

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -17,7 +17,6 @@ pub fn setup(
     mut commands: Commands,
     asset_server: ResMut<AssetServer>,
     mut materials: ResMut<Assets<BackgroundMaterial>>,
-    mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let image = asset_server.load("space_test.png");
     // Queue a command to set the image to be repeating once the image is loaded.
@@ -31,12 +30,9 @@ pub fn setup(
     commands.spawn(Camera2dBundle::default());
 
     // Spawn backgrounds
+    commands.spawn(BackgroundImageBundle::from_image(image, materials.as_mut()).at_z_layer(0.1));
     commands.spawn(
-        BackgroundImageBundle::from_image(image, materials.as_mut(), meshes.as_mut())
-            .at_z_layer(0.1),
-    );
-    commands.spawn(
-        BackgroundImageBundle::from_image(front_layer, materials.as_mut(), meshes.as_mut())
+        BackgroundImageBundle::from_image(front_layer, materials.as_mut())
             .at_z_layer(2.1)
             .with_movement_scale(1.1),
     );

--- a/examples/tiling.rs
+++ b/examples/tiling.rs
@@ -19,7 +19,6 @@ pub fn setup(
     mut commands: Commands,
     asset_server: ResMut<AssetServer>,
     mut materials: ResMut<Assets<BackgroundMaterial>>,
-    mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let image = asset_server.load("test.png");
     // Queue a command to set the image to be repeating once the image is loaded.
@@ -27,10 +26,7 @@ pub fn setup(
 
     commands.spawn(Camera2dBundle::default());
 
-    commands.spawn(
-        BackgroundImageBundle::from_image(image, materials.as_mut(), meshes.as_mut())
-            .at_z_layer(0.1),
-    );
+    commands.spawn(BackgroundImageBundle::from_image(image, materials.as_mut()).at_z_layer(0.1));
 
     // Instructions
     commands.spawn((

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub const TILED_BG_SHADER_HANDLE: HandleUntyped =
 pub const BGLIB_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 429593476423988);
 
+pub const BG_MESH_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Mesh::TYPE_UUID, 12316584166263728426);
+
 /// Prevent shaders from being loaded multiple times, emitting events etc.
 pub static BEVY_TILING_PLUGIN_SHADERS_LOADED: Once = Once::new();
 
@@ -35,6 +38,16 @@ fn load_plugin_shadercode(app: &mut App) {
     );
 
     load_internal_asset!(app, BGLIB_HANDLE, "shaders/bglib.wgsl", Shader::from_wgsl);
+
+    // This is doing the same thing as `load_internal_asset` just not from a file.
+    let mut meshes = app.world.resource_mut::<Assets<Mesh>>();
+    meshes.set_untracked(
+        BG_MESH_HANDLE,
+        Mesh::from(shape::Quad {
+            size: Vec2 { x: 1., y: 1. },
+            ..default()
+        }),
+    );
 }
 
 /// Bevy plugin for tiling backgrounds.
@@ -257,19 +270,10 @@ pub struct CustomBackgroundImageBundle<T: Material2d> {
 }
 
 impl<T: Material2d + ScrollingBackground> CustomBackgroundImageBundle<T> {
-    pub fn with_material(
-        material: T,
-        materials: &mut Assets<T>,
-        meshes: &mut Assets<Mesh>,
-    ) -> Self {
+    pub fn with_material(material: T, materials: &mut Assets<T>) -> Self {
         Self {
             material: materials.add(material),
-            mesh: meshes
-                .add(Mesh::from(shape::Quad {
-                    size: Vec2 { x: 1., y: 1. },
-                    ..default()
-                }))
-                .into(),
+            mesh: BG_MESH_HANDLE.typed().into(),
             transform: Default::default(),
             global_transform: Default::default(),
             visibility: Default::default(),
@@ -293,19 +297,13 @@ impl BackgroundImageBundle {
     pub fn from_image(
         image: Handle<Image>,
         background_materials: &mut Assets<BackgroundMaterial>,
-        meshes: &mut Assets<Mesh>,
     ) -> Self {
         Self {
             material: background_materials.add(BackgroundMaterial {
                 texture: image,
                 movement_scale: 1.0,
             }),
-            mesh: meshes
-                .add(Mesh::from(shape::Quad {
-                    size: Vec2 { x: 1., y: 1. },
-                    ..default()
-                }))
-                .into(),
+            mesh: BG_MESH_HANDLE.typed().into(),
             transform: Default::default(),
             global_transform: Default::default(),
             visibility: Default::default(),


### PR DESCRIPTION
Eliminates the need to pass `&mut Assets<Mesh>` when adding backgrounds and re-uses the same mesh when using multiple backgrounds instead of creating multiple meshes.