### PR TITLE
Fix movement scale after reverting ndc mapping changes

### DIFF
--- a/src/shaders/bglib.wgsl
+++ b/src/shaders/bglib.wgsl
@@ -7,7 +7,7 @@ fn scroll(
     uv: vec2<f32>,
     offset: vec2<f32>,
 ) -> vec4<f32>{
-    let offset = vec2<f32>(-offset.x, offset.y);
+    let offset = vec2<f32>(-offset.x, offset.y) / 2.0;
 
     var uv = uv - (offset * scale);
     let tex_dim = textureDimensions(texture);


### PR DESCRIPTION
After reverting the ndc mapping that was causing issues with pixel art, the movement scale was double what it should be.

Can test with the tiling example. At 1.0 background should stay in line with the red cube, at 0.0 the background move in sync with the camera.