### PR TITLE
Upgrade to Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ homepage = "https://github.com/Braymatter/bevy_tiling_background"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.bevy]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["bevy_asset", "bevy_render", "bevy_core_pipeline", "bevy_sprite"]
 
 [dev-dependencies.bevy]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["bevy_asset", "bevy_render", "bevy_core_pipeline", "bevy_sprite", "bevy_winit", "bevy_text", "bevy_ui", "png"]

--- a/assets/custombg.wgsl
+++ b/assets/custombg.wgsl
@@ -1,9 +1,9 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader
-#import bevy_sprite::mesh2d_view_bindings
+#import bevy_sprite::mesh2d_view_bindings view
 #import bevy_sprite::mesh2d_bindings
-#import bevy_sprite::mesh2d_functions
+#import bevy_sprite::mesh2d_functions mesh2d_position_world_to_clip
 
-#import braymatter::bglib
+#import braymatter::bglib scroll
 
 struct Uniforms {
     scale: f32,
@@ -24,7 +24,7 @@ fn fragment(
 ) -> @location(0) vec4<f32> {
     let scale = uniforms.scale;
     let offset = mesh2d_position_world_to_clip(vec4<f32>(view.world_position.xy, 0.0, 0.0)).xy;
-    let color = scroll(texture, texture_sampler, scale, uv, offset) + uniforms.blend_color;
+    let color = scroll(texture, texture_sampler, scale, uv, offset, view.viewport.zw) + uniforms.blend_color;
     return color;
 }
 

--- a/assets/custombg.wgsl
+++ b/assets/custombg.wgsl
@@ -1,4 +1,4 @@
-#import bevy_core_pipeline::fullscreen_vertex_shader
+#import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
 #import bevy_sprite::mesh2d_view_bindings view
 #import bevy_sprite::mesh2d_bindings
 #import bevy_sprite::mesh2d_functions mesh2d_position_world_to_clip
@@ -19,12 +19,11 @@ var texture_sampler: sampler;
 
 @fragment
 fn fragment(
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    in: FullscreenVertexOutput,
 ) -> @location(0) vec4<f32> {
     let scale = uniforms.scale;
     let offset = mesh2d_position_world_to_clip(vec4<f32>(view.world_position.xy, 0.0, 0.0)).xy;
-    let color = scroll(texture, texture_sampler, scale, uv, offset, view.viewport.zw) + uniforms.blend_color;
+    let color = scroll(texture, texture_sampler, scale, in.uv, offset, view.viewport.zw) + uniforms.blend_color;
     return color;
 }
 

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -6,7 +6,7 @@ use bevy::render::render_resource::{
 use bevy::sprite::Material2dKey;
 use bevy::{
     prelude::*,
-    reflect::TypeUuid,
+    reflect::{TypePath, TypeUuid},
     render::render_resource::{AsBindGroup, ShaderRef},
     sprite::Material2d,
 };
@@ -18,11 +18,11 @@ use bevy_tiling_background::{
 pub fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(TilingBackgroundPlugin::<CustomMaterial>::default())
+        .add_plugins(TilingBackgroundPlugin::<CustomMaterial>::default())
         // Not actually used, putting this here to test the shader_loading flags
-        .add_plugin(TilingBackgroundPlugin::<BackgroundMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(movement)
+        .add_plugins(TilingBackgroundPlugin::<BackgroundMaterial>::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, movement)
         .run()
 }
 
@@ -120,7 +120,7 @@ fn movement(
     }
 }
 
-#[derive(AsBindGroup, Debug, Clone, TypeUuid, Default)]
+#[derive(AsBindGroup, Debug, Clone, TypeUuid, TypePath, Default)]
 #[uuid = "09756d79-32e9-4dc4-bb95-b373370815e3"]
 pub struct CustomMaterial {
     #[uniform(0)]

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -7,9 +7,9 @@ use bevy_tiling_background::{
 pub fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(TilingBackgroundPlugin::<BackgroundMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(movement)
+        .add_plugins(TilingBackgroundPlugin::<BackgroundMaterial>::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, movement)
         .run()
 }
 

--- a/examples/tiling.rs
+++ b/examples/tiling.rs
@@ -7,11 +7,11 @@ use bevy_tiling_background::{
 pub fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_linear()))
-        .add_plugin(TilingBackgroundPlugin::<BackgroundMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(movement)
-        .add_system(update_instructions)
-        .add_system(update_movement_scale_system.in_base_set(CoreSet::PostUpdate))
+        .add_plugins(TilingBackgroundPlugin::<BackgroundMaterial>::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, movement)
+        .add_systems(Update, update_instructions)
+        .add_systems(PostUpdate, update_movement_scale_system)
         .run()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,14 +70,14 @@ where
             load_plugin_shadercode(app);
         });
 
-        app.add_plugin(Material2dPlugin::<T>::default())
+        app.add_plugins(Material2dPlugin::<T>::default())
             .register_type::<BackgroundMovementScale>()
             .insert_resource(UpdateSamplerRepeating::default())
-            .add_system(Self::on_window_resize.in_base_set(CoreSet::PostUpdate))
-            .add_system(Self::on_background_added)
-            .add_system(Self::queue_update_sampler)
-            .add_system(Self::update_movement_scale_system)
-            .add_system(update_sampler_on_loaded_system);
+            .add_systems(PostUpdate, Self::on_window_resize)
+            .add_systems(Update, Self::on_background_added)
+            .add_systems(Update, Self::queue_update_sampler)
+            .add_systems(Update, Self::update_movement_scale_system)
+            .add_systems(Update, update_sampler_on_loaded_system);
     }
 }
 
@@ -211,7 +211,7 @@ fn update_sampler_on_loaded_system(
                 update_sampler.0.remove(index);
             }
             LoadState::Loaded => {
-                let mut bg_texture = images
+                let bg_texture = images
                     .get_mut(&handle)
                     .expect("the image should be loaded at this point");
 
@@ -328,7 +328,7 @@ struct SetImageRepeatingCommand {
 }
 
 impl Command for SetImageRepeatingCommand {
-    fn write(self, world: &mut World) {
+    fn apply(self, world: &mut World) {
         let mut samplers = world.resource_mut::<UpdateSamplerRepeating>();
         samplers.0.push(self.image);
     }

--- a/src/shaders/background.wgsl
+++ b/src/shaders/background.wgsl
@@ -1,4 +1,4 @@
-#import bevy_core_pipeline::fullscreen_vertex_shader
+#import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
 #import bevy_sprite::mesh2d_view_bindings view
 #import bevy_sprite::mesh2d_bindings
 #import bevy_sprite::mesh2d_functions mesh2d_position_world_to_clip
@@ -16,12 +16,11 @@ var texture_sampler: sampler;
 
 @fragment
 fn fragment(
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    in: FullscreenVertexOutput,
 ) -> @location(0) vec4<f32> {
     let scale = uniforms.scale;
     let offset = mesh2d_position_world_to_clip(vec4<f32>(view.world_position.xy, 0.0, 0.0)).xy;
-    let color = scroll(texture, texture_sampler, scale, uv, offset, view.viewport.zw);
+    let color = scroll(texture, texture_sampler, scale, in.uv, offset, view.viewport.zw);
     return color;
 }
 

--- a/src/shaders/background.wgsl
+++ b/src/shaders/background.wgsl
@@ -1,8 +1,8 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader
-#import bevy_sprite::mesh2d_view_bindings
+#import bevy_sprite::mesh2d_view_bindings view
 #import bevy_sprite::mesh2d_bindings
-#import bevy_sprite::mesh2d_functions
-#import braymatter::bglib
+#import bevy_sprite::mesh2d_functions mesh2d_position_world_to_clip
+#import braymatter::bglib scroll
 struct Uniforms {
     scale: f32,
 };
@@ -21,7 +21,7 @@ fn fragment(
 ) -> @location(0) vec4<f32> {
     let scale = uniforms.scale;
     let offset = mesh2d_position_world_to_clip(vec4<f32>(view.world_position.xy, 0.0, 0.0)).xy;
-    let color = scroll(texture, texture_sampler, scale, uv, offset);
+    let color = scroll(texture, texture_sampler, scale, uv, offset, view.viewport.zw);
     return color;
 }
 

--- a/src/shaders/bglib.wgsl
+++ b/src/shaders/bglib.wgsl
@@ -2,17 +2,18 @@
 
 fn scroll(
     texture: texture_2d<f32>,
-    texture_sampler: sampler, 
+    texture_sampler: sampler,
     scale: f32,
     uv: vec2<f32>,
     offset: vec2<f32>,
+    viewport_size: vec2<f32>,
 ) -> vec4<f32>{
     let offset = vec2<f32>(-offset.x, offset.y);
 
     var uv = uv - (offset * scale);
     let tex_dim = textureDimensions(texture);
-    
-    uv = uv * ( view.viewport.zw / vec2<f32>(tex_dim) );
+
+    uv = uv * ( viewport_size / vec2<f32>(tex_dim) );
     let color = textureSample(texture, texture_sampler, uv  );
     return color;
 }


### PR DESCRIPTION
Pretty straightforward migration, but I think some changes in shader import behavior necessitated adding the viewport size as a parameter of `scroll` in the shaders.