### PR TITLE
Fix Linux render issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/Braymatter/bevy_tiling_background"
 [dependencies.bevy]
 version = "0.15"
 default-features = false
-features = ["bevy_asset", "bevy_render", "bevy_core_pipeline", "bevy_sprite", "bevy_winit"]
+features = ["bevy_asset", "bevy_render", "bevy_core_pipeline", "bevy_sprite", "bevy_winit", "x11", "wayland"]
 
 [dev-dependencies.bevy]
 version = "0.15"
@@ -30,4 +30,6 @@ features = [
     "multi_threaded",
     "png",
     "webgl2",
+    "x11",
+    "wayland",
 ]


### PR DESCRIPTION
I tried to run the example from the readme on my Linux (Fedora KDE, modern AMD hardware) desktop, and it failed:
```
$ cargo run --example tiling
   Compiling wgpu-hal v23.0.1
   Compiling naga_oil v0.16.0
   Compiling bevy_ecs v0.15.2
   Compiling bevy_math v0.15.2
   Compiling cosmic-text v0.12.1
   Compiling winit v0.30.9
error: The platform you're compiling for is not supported by winit
  --> /home/caleb/.asdf/installs/rust/stable/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.9/src/platform_impl/mod.rs:78:1
   |
78 | compile_error!("The platform you're compiling for is not supported by winit");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `self::platform`
  --> /home/caleb/.asdf/installs/rust/stable/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.9/src/platform_impl/mod.rs:34:15
   |
34 | pub use self::platform::*;
   |               ^^^^^^^^ could not find `platform` in `self`

error[E0432]: unresolved imports `crate::platform_impl::PlatformCustomCursor`, `crate::platform_impl::PlatformCustomCursorSource`
 --> /home/caleb/.asdf/installs/rust/stable/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.9/src/cursor.rs:8:28
  |
8 | use crate::platform_impl::{PlatformCustomCursor, PlatformCustomCursorSource};
  |                            ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^ no `PlatformCustomCursorSource` in `platform_impl`
  |                            |
  |                            no `PlatformCustomCursor` in `platform_impl`

error[E0432]: unresolved import `crate::platform_impl::PlatformIcon`
 --> /home/caleb/.asdf/installs/rust/stable/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.9/src/icon.rs:1:5
  |
1 | use crate::platform_impl::PlatformIcon;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `PlatformIcon` in `platform_impl`

error[E0432]: unresolved import `crate::platform_impl::PlatformSpecificWindowAttributes`
 --> /home/caleb/.asdf/installs/rust/stable/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.9/src/window.rs:7:34
  |
7 | use crate::platform_impl::{self, PlatformSpecificWindowAttributes};
  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `PlatformSpecificWindowAttributes` in `platform_impl`

error[E0369]: binary operation `==` cannot be applied to type `&std::option::Option<MonitorHandle>`
    --> /home/caleb/.asdf/installs/rust/stable/registry/src/index.crates.io-6f17d22bba15001f/winit-0.30.9/src/window.rs:1751:16
     |
1746 | #[derive(Clone, Debug, PartialEq, Eq)]
     |                        --------- in this derive macro expansion
...
1751 |     Borderless(Option<MonitorHandle>),
     |                ^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0369, E0432.
For more information about an error, try `rustc --explain E0369`.
error: could not compile `winit` (lib) due to 6 previous errors
warning: build failed, waiting for other jobs to finish...
```

AI suggested this fix, I'm not familiar enough with winit to be sure of it. But I was able to run all the examples with it.